### PR TITLE
V0.2.0 dev

### DIFF
--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -51,16 +51,25 @@
 #'                             ALP = "Alkaline Phosphatase (U/L)"))
 #' 
 #' ## Create eDISH figure using a premade settings list
+#' group_cols_vec <- c("TRTP","SEX", "AGEGR1")
+#' 
+#' filters_df <- data.frame(
+#'   value_col=c("TRTA", "SEX", "RACE", "AGEGR1"),
+#'   label = c("Treatment", "Sex", "RACE", "Age group")
+#' )
+#' 
 #' settingsl <- list(id_col = "USUBJID",
 #'       value_col = "AVAL", 
 #'       measure_col = "PARAM", 
 #'       visitn_col = "VISITNUM", 
 #'       normal_col_low = "A1LO", 
 #'       normal_col_high = "A1HI", 
+#'       group_cols = group_cols_vec,
+#'       filters = filters_df,
 #'       measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
-#'                              +                             AST = "Aspartate Aminotransferase (U/L)",
-#'                              +                             TB = "Bilirubin (umol/L)",
-#'                              +                             ALP = "Alkaline Phosphatase (U/L)"))
+#'                             AST = "Aspartate Aminotransferase (U/L)",
+#'                             TB = "Bilirubin (umol/L)",
+#'                             ALP = "Alkaline Phosphatase (U/L)"))
 #' eDISH(data=adlbc, settings = settingsl)
 #' 
 #' }

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -13,16 +13,14 @@
 #' @param visitn_col Visit number variable name. Default: \code{"VISITN"}. 
 #' @param baseline_visitn Value of baseline visit number. Used to calculate mDish. Default: \code{1}. 
 #' @param filters An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.
-#' @param group_cols  An optional vector of names of grouping variables. Default: \code{NULL}.
+#' @param group_cols An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.
 #' @param measure_values A list defining the data values from \code{measure_col} for the lab measures 
 #' used in eDish evaluations. Default: \code{list(ALT = 'Aminotransferase, alanine (ALT)', 
 #' AST = 'Aminotransferase, aspartate (AST)', TB = 'Total Bilirubin', ALP = 'Alkaline phosphatase (ALP)')}.
 #' @param x_options Specifies variable options for the x-axis using the key values from \code{measure_values} (e.g. "ALT"). 
 #' When multiple options are specified, a control allowing the user to interactively change the x variable is shown. Default: \code{c("ALT", "AST", "ALP")}.
 #' @param y_options Specifies variable options for the y-axis using the key values from \code{measure_values} (e.g. "TB"). 
-#' When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{"TB"}.
-#' @param measure_bounds Sets upper and lower percentiles used for defining outliers in the "Lab Summary Table"
-#' in the participant details section. Default: \code{c(0.01, 0.99)}.
+#' When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{c("TB", "ALP")}.
 #' @param visit_window Default visit window used to highlight eDish points where x and y measures occurred within the specified number of days. 
 #' Editable by user after render. Default: \code{30}.
 #' @param r_ratio_filter Specifies whether the R Ratio filter should be shown. R ratio is defined as: 
@@ -55,8 +53,7 @@ eDISH <- function(data,
                                         TB = "Total Bilirubin",
                                         ALP = "Alkaline phosphatase (ALP)"),
                   x_options = c("ALT", "AST", "ALP"),
-                  y_options = "TB", 
-                  measure_bounds = c(0.01, 0.99),
+                  y_options = c("TB", "ALP"), # temporarily making this a vector of length 2 until JS side fixed
                   visit_window = 30,
                   r_ratio_filter = TRUE,
                   r_ratio_cut = 0,
@@ -83,7 +80,6 @@ eDISH <- function(data,
         measure_values = measure_values,
         x_options = x_options,
         y_options = y_options,
-        measure_bounds = measure_bounds,
         visit_window = visit_window,
         r_ratio_filter = r_ratio_filter,
         r_ratio_cut = r_ratio_cut,

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -32,6 +32,7 @@
 #'  No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: This interactive graphic is 
 #'  not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
 #'  standard operating procedures."}.
+#' @param settings Optional list of settings arguments.  If provided, all other function parameters are ignored. Default: \code{NULL}.
 #'  
 #' @import htmlwidgets
 #'
@@ -58,38 +59,47 @@ eDISH <- function(data,
                   r_ratio_filter = TRUE,
                   r_ratio_cut = 0,
                   showTitle = TRUE,
-                  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.") {
+                  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.",
+                  settings = NULL) {
 
 
-  # forward options using x
-  rSettings = list(
-    data = data,
-    settings = jsonlite::toJSON(
-      list(
-        id_col = id_col, 
-        value_col = value_col,
-        measure_col = measure_col,
-        unit_col = unit_col,
-        normal_col_low = normal_col_low,
-        normal_col_high = normal_col_high,
-        visit_col = visit_col,
-        visitn_col = visitn_col,
-        baseline_visitn = baseline_visitn,
-        filters = filters,
-        group_cols = group_cols,
-        measure_values = measure_values,
-        x_options = x_options,
-        y_options = y_options,
-        visit_window = visit_window,
-        r_ratio_filter = r_ratio_filter,
-        r_ratio_cut = r_ratio_cut,
-        showTitle = showTitle,
-        warningText = warningText
-      ),
-      auto_unbox = TRUE,
-      dataframe = "rows"
+  # forward options using rSettings
+  if (is.null(settings)){
+    rSettings = list(
+      data = data,
+      settings = jsonlite::toJSON(
+        list(
+          id_col = id_col, 
+          value_col = value_col,
+          measure_col = measure_col,
+          unit_col = unit_col,
+          normal_col_low = normal_col_low,
+          normal_col_high = normal_col_high,
+          visit_col = visit_col,
+          visitn_col = visitn_col,
+          baseline_visitn = baseline_visitn,
+          filters = filters,
+          group_cols = group_cols,
+          measure_values = measure_values,
+          x_options = x_options,
+          y_options = y_options,
+          visit_window = visit_window,
+          r_ratio_filter = r_ratio_filter,
+          r_ratio_cut = r_ratio_cut,
+          showTitle = showTitle,
+          warningText = warningText
+        ),
+        auto_unbox = TRUE,
+        dataframe = "rows"
+      )
+    )    
+  } else{
+    rSettings = list(
+      data = data,
+      settings = jsonlite::toJSON(settings)
     )
-  )
+  }
+
 
   # create widget
   htmlwidgets::createWidget(

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -3,15 +3,121 @@
 #' This function creates an interactive graphic for the Evaluation of Drug-Induced Serious Hepatotoxicity (eDISH)
 #'
 #' @param data A data frame containing the labs data. Data must be structured as one record per study participant per time point per lab measure. 
-#' 
+#' @param id_col Unique subject identifier variable name. Default: \code{"USUBJID"}.
+#' @param value_col Lab result variable name. Default: \code{"STRESN"}. 
+#' @param measure_col Lab measure variable name. Default: \code{"TEST"}.
+#' @param unit_col Lab measure unit variable name. Default: \code{"STRESU"}.
+#' @param normal_col_low Lower limit of normal variable name. Default: \code{"STNRLO"}.
+#' @param normal_col_high Upper limit of normal variable name. Default: \code{"STNRHI"}. 
+#' @param visitn_col Visit number variable name. Default: \code{"VISITN"}. 
+#' @param baseline_visitn Value of baseline visit number. Used to calculate mDish. Default: \code{1}. 
+#' @param filters An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.
+#' @param group_cols  An optional vector of names of grouping variables. Default: \code{NULL}.
+#' @param measure_values A list defining the data values from \code{measure_col} for the lab measures 
+#' used in eDish evaluations. Default: \code{list(ALT = 'Aminotransferase, alanine (ALT)', 
+#' AST = 'Aminotransferase, aspartate (AST)', TB = 'Total Bilirubin', ALP = 'Alkaline phosphatase (ALP)')}.
+#' @param x_options Specifies variable options for the x-axis using the key values from \code{measure_values} (e.g. "ALT"). 
+#' When multiple options are specified, a control allowing the user to interactively change the x variable is shown. Default: \code{c("ALT", "AST", "ALP")}.
+#' @param y_options Specifies variable options for the y-axis using the key values from \code{measure_values} (e.g. "TB"). 
+#' When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{"TB"}.
+#' @param measure_bounds Sets upper and lower percentiles used for defining outliers in the "Lab Summary Table"
+#' in the participant details section. Default: \code{c(0.01, 0.99)}.
+#' @param visit_window Default visit window used to highlight eDish points where x and y measures occurred within the specified number of days. 
+#' Editable by user after render. Default: \code{30}.
+#' @param r_ratio_filter Specifies whether the R Ratio filter should be shown. R ratio is defined as: 
+#' (ALT value/ULN for ALT) / (ALP value/ULN for ALP). Default: \code{TRUE}.
+#' @param r_ratio_cut Default cut point for R Ratio filter. Ignored when \code{r_ratio_filter = FALSE}. 
+#' User can update this setting via the UI when \code{r_ratio_filter = TRUE}. Default: \code{0}.
+#' @param showTitle Specifies whether the title should be drawn above the controls. Default: \code{TRUE}.
+#' @param warningText Informational text to be displayed near the top of the controls (beneath the title, if any).
+#'  No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: This interactive graphic is 
+#'  not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
+#'  standard operating procedures."}.
+#'  
 #' @import htmlwidgets
 #'
 #' @export
-eDISH <- function(data) {
+eDISH <- function(data,
+                  id_col = "USUBJID",
+                  value_col = "STRESN",
+                  measure_col = "TEST",
+                  unit_col = "STRESU",
+                  normal_col_low = "STNRLO",
+                  normal_col_high = "STNRHI",
+                  visitn_col = "VISITN",
+                  baseline_visitn = 1,
+                  filters = NULL,
+                  group_cols = NULL,
+                  measure_values = list(ALT = "Aminotransferase, alanine (ALT)",
+                                        AST = "Aminotransferase, aspartate (AST)",
+                                        TB = "Total Bilirubin",
+                                        ALP = "Alkaline phosphatase (ALP)"),
+                  x_options = c("ALT", "AST", "ALP"),
+                  y_options = "TB", 
+                  measure_bounds = c(0.01, 0.99),
+                  visit_window = 30,
+                  r_ratio_filter = TRUE,
+                  r_ratio_cut = 0,
+                  showTitle = TRUE,
+                  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.") {
+
+  
+  # # define filters object
+  # filters <- filters
+  # if (is.null(filters)){
+  #   if (is.null(filters_value_col)){
+  #     filters <- NULL    # no filters specified
+  #   } else {
+  #     if (is.null(filters_label)){
+  #       filters_label = filters_value_col
+  #     }
+  #     filters <- data.frame(value_col = filters_value_col,   
+  #                           label = filters_label)
+  #   }
+  # }
+  # 
+  # # define group_cols object
+  # group_cols <- group_cols
+  # if (is.null(group_cols)){
+  #   if (is.null(group_cols_value_col)){
+  #     group_cols <- NULL    # no group_cols specified
+  #   } else {
+  #     if (is.null(group_cols_label)){
+  #       group_cols_label = group_cols_value_col
+  #     }
+  #     group_cols <- data.frame(value_col = group_cols_value_col,   
+  #                           label = group_cols_label)
+  #   }
+  # }
 
   # forward options using x
   rSettings = list(
-    data = data
+    data = data,
+    settings = jsonlite::toJSON(
+      list(
+        id_col = id_col, 
+        value_col = value_col,
+        measure_col = measure_col,
+        unit_col = unit_col,
+        normal_col_low = normal_col_low,
+        normal_col_high = normal_col_high,
+        visitn_col = visitn_col,
+        baseline_visitn = baseline_visitn,
+        filters = filters,
+        group_cols = group_cols,
+        measure_values = measure_values,
+        x_options = x_options,
+        y_options = y_options,
+        measure_bounds = measure_bounds,
+        visit_window = visit_window,
+        r_ratio_filter = r_ratio_filter,
+        r_ratio_cut = r_ratio_cut,
+        showTitle = showTitle,
+        warningText = warningText
+      ),
+      auto_unbox = TRUE,
+      dataframe = "rows"
+    )
   )
 
   # create widget

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -20,8 +20,8 @@ eDISH <- function(data) {
     rSettings,
    # width = width,
    # height = height,
-    package = 'ReDish' #,
-   # sizingPolicy = htmlwidgets::sizingPolicy(viewer.fill=FALSE)
+    package = 'ReDish',
+    sizingPolicy = htmlwidgets::sizingPolicy(viewer.suppress = TRUE)
   )
 }
 

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -34,6 +34,21 @@
 #'  standard operating procedures."}.
 #' @param settings Optional list of settings arguments.  If provided, all other function parameters are ignored. Default: \code{NULL}.
 #'  
+#' @examples 
+#' \dontrun{
+#' eDISH(data=adlbc, 
+#'       id_col = "USUBJID",
+#'       value_col = "AVAL", 
+#'       measure_col = "PARAM", 
+#'       visitn_col = "VISITNUM", 
+#'       normal_col_low = "A1LO", 
+#'       normal_col_high = "A1HI", 
+#'       measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
+#'                             AST = "Aspartate Aminotransferase (U/L)",
+#'                             TB = "Bilirubin (umol/L)",
+#'                             ALP = "Alkaline Phosphatase (U/L)"))
+#' }
+#' 
 #' @import htmlwidgets
 #'
 #' @export
@@ -90,7 +105,8 @@ eDISH <- function(data,
           warningText = warningText
         ),
         auto_unbox = TRUE,
-        dataframe = "rows"
+        dataframe = "rows",
+        null = "null"
       )
     )    
   } else{

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -32,10 +32,12 @@
 #'  No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: This interactive graphic is 
 #'  not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
 #'  standard operating procedures."}.
-#' @param settings Optional list of settings arguments.  If provided, all other function parameters are ignored. Default: \code{NULL}.
+#' @param settings Optional list of settings arguments to be converted to JSON using \code{jsonlite::toJSON(settings, auto_unbox = TRUE, dataframe = "rows", null = "null")}.  If provided, all other function parameters are ignored. Default: \code{NULL}.
 #'  
 #' @examples 
 #' \dontrun{
+#' 
+#' ## Create eDISH figure customized to user data
 #' eDISH(data=adlbc, 
 #'       id_col = "USUBJID",
 #'       value_col = "AVAL", 
@@ -47,6 +49,20 @@
 #'                             AST = "Aspartate Aminotransferase (U/L)",
 #'                             TB = "Bilirubin (umol/L)",
 #'                             ALP = "Alkaline Phosphatase (U/L)"))
+#' 
+#' ## Create eDISH figure using a premade settings list
+#' settingsl <- list(id_col = "USUBJID",
+#'       value_col = "AVAL", 
+#'       measure_col = "PARAM", 
+#'       visitn_col = "VISITNUM", 
+#'       normal_col_low = "A1LO", 
+#'       normal_col_high = "A1HI", 
+#'       measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
+#'                              +                             AST = "Aspartate Aminotransferase (U/L)",
+#'                              +                             TB = "Bilirubin (umol/L)",
+#'                              +                             ALP = "Alkaline Phosphatase (U/L)"))
+#' eDISH(data=adlbc, settings = settingsl)
+#' 
 #' }
 #' 
 #' @import htmlwidgets
@@ -112,7 +128,10 @@ eDISH <- function(data,
   } else{
     rSettings = list(
       data = data,
-      settings = jsonlite::toJSON(settings)
+      settings = jsonlite::toJSON(settings,
+                                  auto_unbox = TRUE,
+                                  dataframe = "rows",
+                                  null = "null")
     )
   }
 

--- a/R/eDISH.R
+++ b/R/eDISH.R
@@ -9,6 +9,7 @@
 #' @param unit_col Lab measure unit variable name. Default: \code{"STRESU"}.
 #' @param normal_col_low Lower limit of normal variable name. Default: \code{"STNRLO"}.
 #' @param normal_col_high Upper limit of normal variable name. Default: \code{"STNRHI"}. 
+#' @param visit_col Visit variable name. Default: \code{"VISIT"}.
 #' @param visitn_col Visit number variable name. Default: \code{"VISITN"}. 
 #' @param baseline_visitn Value of baseline visit number. Used to calculate mDish. Default: \code{1}. 
 #' @param filters An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.
@@ -44,6 +45,7 @@ eDISH <- function(data,
                   unit_col = "STRESU",
                   normal_col_low = "STNRLO",
                   normal_col_high = "STNRHI",
+                  visit_col = "VISIT",
                   visitn_col = "VISITN",
                   baseline_visitn = 1,
                   filters = NULL,
@@ -61,34 +63,6 @@ eDISH <- function(data,
                   showTitle = TRUE,
                   warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.") {
 
-  
-  # # define filters object
-  # filters <- filters
-  # if (is.null(filters)){
-  #   if (is.null(filters_value_col)){
-  #     filters <- NULL    # no filters specified
-  #   } else {
-  #     if (is.null(filters_label)){
-  #       filters_label = filters_value_col
-  #     }
-  #     filters <- data.frame(value_col = filters_value_col,   
-  #                           label = filters_label)
-  #   }
-  # }
-  # 
-  # # define group_cols object
-  # group_cols <- group_cols
-  # if (is.null(group_cols)){
-  #   if (is.null(group_cols_value_col)){
-  #     group_cols <- NULL    # no group_cols specified
-  #   } else {
-  #     if (is.null(group_cols_label)){
-  #       group_cols_label = group_cols_value_col
-  #     }
-  #     group_cols <- data.frame(value_col = group_cols_value_col,   
-  #                           label = group_cols_label)
-  #   }
-  # }
 
   # forward options using x
   rSettings = list(
@@ -101,6 +75,7 @@ eDISH <- function(data,
         unit_col = unit_col,
         normal_col_low = normal_col_low,
         normal_col_high = normal_col_high,
+        visit_col = visit_col,
         visitn_col = visitn_col,
         baseline_visitn = baseline_visitn,
         filters = filters,

--- a/inst/htmlwidgets/eDISH.js
+++ b/inst/htmlwidgets/eDISH.js
@@ -15,41 +15,62 @@ HTMLWidgets.widget({
 
         el.innerHTML = "<div class='edish'></div>";
 
-        let settings = {
-            max_width: 600,
-            value_col: 'AVAL',
-            measure_col: 'PARAM',
-            visitn_col: 'VISITNUM',
-            studyday_col: 'ADY',
-            normal_col_low: 'A1LO',
-            normal_col_high: 'A1HI',
-            id_col: 'USUBJID',
-            group_cols: ['TRTA','RACE','AGEGR1'],
-            filters: [
-                {
-                    value_col: 'TRTA',
-                    label: 'Treatment'
-                },
-                {
-                    value_col: 'SEX',
-                    label: 'Sex'
-                },
-                {
-                    value_col: 'RACE',
-                    label: 'Race'
-                },
-                {
-                    value_col: 'AGEGR1',
-                    label: 'Age group'
-                },
-            ],
-            measure_values:{
-              'ALT':'Alanine Aminotransferase (U/L)',
-              'AST':'Aspartate Aminotransferase (U/L)',
-              'TB':'Bilirubin (umol/L)',
-              'ALP':'Alkaline Phosphatase (U/L)'
-            }
-        };
+        let settings = rSettings.settings;
+        settings.max_width = 600;
+        
+       // let settings = {
+        //    max_width: 600,
+           // value_col: 'AVAL',
+           // measure_col: 'PARAM',
+           // visitn_col: 'VISITNUM',
+           //studyday_col: 'ADY',
+           //normal_col_low: 'A1LO',
+           // normal_col_high: 'A1HI',
+           // id_col: 'USUBJID',
+           // group_cols: ['TRTA','RACE','AGEGR1'],
+           // filters: [
+           //     {
+           //         value_col: 'TRTA',
+          //          label: 'Treatment'
+          //     },
+          //      {
+          //          value_col: 'SEX',
+         //           label: 'Sex'
+         //       },
+         //       {
+         //           value_col: 'RACE',
+         //           label: 'Race'
+         //       },
+         //       {
+         //           value_col: 'AGEGR1',
+         //           label: 'Age group'
+        //        },
+        //    ],
+       //              //   measure_values:{
+        //     'ALT':'Alanine Aminotransferase (U/L)',
+        //      'AST':'Aspartate Aminotransferase (U/L)',
+        //     'TB':'Bilirubin (umol/L)',
+        //    'ALP':'Alkaline Phosphatase (U/L)'
+        //   }
+       //     value_col: rSettings.settings.value_col,
+       //     measure_col: rSettings.settings.measure_col,
+         //   visitn_col: rSettings.settings.visitn_col,
+           // normal_col_low: rSettings.settings.normal_col_low,
+      //      normal_col_high: rSettings.settings.normal_col_high,
+      //      id_col: rSettings.settings.id_col,
+      //      baseline_visitn: rSettings.settings.baseline_visitn,
+      //      filters: rSettings.settings.filters,
+      //      group_cols: rSettings.settings.group_cols,
+      //      measure_values: rSettings.settings.measure_values,
+      //      x_options: rSettings.settings.x_options,
+      //      y_options: rSettings.settings.y_options,
+      //      measure_bounds: rSettings.settings.measure_bounds,
+      //      visit_window: rSettings.settings.visit_window,
+      //      r_ratio_filter: rSettings.settings.r_ratio_filter,
+      //      r_ratio_cut: rSettings.settings.r_ratio_cut,
+      //      showTitle: rSettings.settings.showTitle,
+      //      warningText: rSettings.settings.warningText
+      //  };
         
          rSettings.data = HTMLWidgets.dataframeToD3(rSettings.data);
 

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -7,8 +7,8 @@
 eDISH(data, id_col = "USUBJID", value_col = "STRESN",
   measure_col = "TEST", unit_col = "STRESU",
   normal_col_low = "STNRLO", normal_col_high = "STNRHI",
-  visitn_col = "VISITN", baseline_visitn = 1, filters = NULL,
-  group_cols = NULL, measure_values = list(ALT =
+  visit_col = "VISIT", visitn_col = "VISITN", baseline_visitn = 1,
+  filters = NULL, group_cols = NULL, measure_values = list(ALT =
   "Aminotransferase, alanine (ALT)", AST =
   "Aminotransferase, aspartate (AST)", TB = "Total Bilirubin", ALP =
   "Alkaline phosphatase (ALP)"), x_options = c("ALT", "AST", "ALP"),
@@ -31,6 +31,8 @@ eDISH(data, id_col = "USUBJID", value_col = "STRESN",
 \item{normal_col_low}{Lower limit of normal variable name. Default: \code{"STNRLO"}.}
 
 \item{normal_col_high}{Upper limit of normal variable name. Default: \code{"STNRHI"}.}
+
+\item{visit_col}{Visit variable name. Default: \code{"VISIT"}.}
 
 \item{visitn_col}{Visit number variable name. Default: \code{"VISITN"}.}
 

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -12,9 +12,8 @@ eDISH(data, id_col = "USUBJID", value_col = "STRESN",
   "Aminotransferase, alanine (ALT)", AST =
   "Aminotransferase, aspartate (AST)", TB = "Total Bilirubin", ALP =
   "Alkaline phosphatase (ALP)"), x_options = c("ALT", "AST", "ALP"),
-  y_options = "TB", measure_bounds = c(0.01, 0.99),
-  visit_window = 30, r_ratio_filter = TRUE, r_ratio_cut = 0,
-  showTitle = TRUE,
+  y_options = c("TB", "ALP"), visit_window = 30,
+  r_ratio_filter = TRUE, r_ratio_cut = 0, showTitle = TRUE,
   warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.")
 }
 \arguments{
@@ -40,7 +39,7 @@ eDISH(data, id_col = "USUBJID", value_col = "STRESN",
 
 \item{filters}{An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.}
 
-\item{group_cols}{An optional vector of names of grouping variables. Default: \code{NULL}.}
+\item{group_cols}{An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.}
 
 \item{measure_values}{A list defining the data values from \code{measure_col} for the lab measures 
 used in eDish evaluations. Default: \code{list(ALT = 'Aminotransferase, alanine (ALT)', 
@@ -50,10 +49,7 @@ AST = 'Aminotransferase, aspartate (AST)', TB = 'Total Bilirubin', ALP = 'Alkali
 When multiple options are specified, a control allowing the user to interactively change the x variable is shown. Default: \code{c("ALT", "AST", "ALP")}.}
 
 \item{y_options}{Specifies variable options for the y-axis using the key values from \code{measure_values} (e.g. "TB"). 
-When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{"TB"}.}
-
-\item{measure_bounds}{Sets upper and lower percentiles used for defining outliers in the "Lab Summary Table"
-in the participant details section. Default: \code{c(0.01, 0.99)}.}
+When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{c("TB", "ALP")}.}
 
 \item{visit_window}{Default visit window used to highlight eDish points where x and y measures occurred within the specified number of days. 
 Editable by user after render. Default: \code{30}.}

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -4,10 +4,70 @@
 \alias{eDISH}
 \title{Create an eDISH widget}
 \usage{
-eDISH(data)
+eDISH(data, id_col = "USUBJID", value_col = "STRESN",
+  measure_col = "TEST", unit_col = "STRESU",
+  normal_col_low = "STNRLO", normal_col_high = "STNRHI",
+  visitn_col = "VISITN", baseline_visitn = 1, filters = NULL,
+  group_cols = NULL, measure_values = list(ALT =
+  "Aminotransferase, alanine (ALT)", AST =
+  "Aminotransferase, aspartate (AST)", TB = "Total Bilirubin", ALP =
+  "Alkaline phosphatase (ALP)"), x_options = c("ALT", "AST", "ALP"),
+  y_options = "TB", measure_bounds = c(0.01, 0.99),
+  visit_window = 30, r_ratio_filter = TRUE, r_ratio_cut = 0,
+  showTitle = TRUE,
+  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.")
 }
 \arguments{
 \item{data}{A data frame containing the labs data. Data must be structured as one record per study participant per time point per lab measure.}
+
+\item{id_col}{Unique subject identifier variable name. Default: \code{"USUBJID"}.}
+
+\item{value_col}{Lab result variable name. Default: \code{"STRESN"}.}
+
+\item{measure_col}{Lab measure variable name. Default: \code{"TEST"}.}
+
+\item{unit_col}{Lab measure unit variable name. Default: \code{"STRESU"}.}
+
+\item{normal_col_low}{Lower limit of normal variable name. Default: \code{"STNRLO"}.}
+
+\item{normal_col_high}{Upper limit of normal variable name. Default: \code{"STNRHI"}.}
+
+\item{visitn_col}{Visit number variable name. Default: \code{"VISITN"}.}
+
+\item{baseline_visitn}{Value of baseline visit number. Used to calculate mDish. Default: \code{1}.}
+
+\item{filters}{An optional data frame of filters ("value_col") and associated metadata ("label"). Default: \code{NULL}.}
+
+\item{group_cols}{An optional vector of names of grouping variables. Default: \code{NULL}.}
+
+\item{measure_values}{A list defining the data values from \code{measure_col} for the lab measures 
+used in eDish evaluations. Default: \code{list(ALT = 'Aminotransferase, alanine (ALT)', 
+AST = 'Aminotransferase, aspartate (AST)', TB = 'Total Bilirubin', ALP = 'Alkaline phosphatase (ALP)')}.}
+
+\item{x_options}{Specifies variable options for the x-axis using the key values from \code{measure_values} (e.g. "ALT"). 
+When multiple options are specified, a control allowing the user to interactively change the x variable is shown. Default: \code{c("ALT", "AST", "ALP")}.}
+
+\item{y_options}{Specifies variable options for the y-axis using the key values from \code{measure_values} (e.g. "TB"). 
+When multiple options are specified, a control allowing the user to interactively change the y variable is shown. Default: \code{"TB"}.}
+
+\item{measure_bounds}{Sets upper and lower percentiles used for defining outliers in the "Lab Summary Table"
+in the participant details section. Default: \code{c(0.01, 0.99)}.}
+
+\item{visit_window}{Default visit window used to highlight eDish points where x and y measures occurred within the specified number of days. 
+Editable by user after render. Default: \code{30}.}
+
+\item{r_ratio_filter}{Specifies whether the R Ratio filter should be shown. R ratio is defined as: 
+(ALT value/ULN for ALT) / (ALP value/ULN for ALP). Default: \code{TRUE}.}
+
+\item{r_ratio_cut}{Default cut point for R Ratio filter. Ignored when \code{r_ratio_filter = FALSE}. 
+User can update this setting via the UI when \code{r_ratio_filter = TRUE}. Default: \code{0}.}
+
+\item{showTitle}{Specifies whether the title should be drawn above the controls. Default: \code{TRUE}.}
+
+\item{warningText}{Informational text to be displayed near the top of the controls (beneath the title, if any).
+No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: This interactive graphic is 
+not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
+standard operating procedures."}.}
 }
 \description{
 This function creates an interactive graphic for the Evaluation of Drug-Induced Serious Hepatotoxicity (eDISH)

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -14,7 +14,8 @@ eDISH(data, id_col = "USUBJID", value_col = "STRESN",
   "Alkaline phosphatase (ALP)"), x_options = c("ALT", "AST", "ALP"),
   y_options = c("TB", "ALP"), visit_window = 30,
   r_ratio_filter = TRUE, r_ratio_cut = 0, showTitle = TRUE,
-  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.")
+  warningText = "Caution: This interactive graphic is not validated. Any clinical recommendations based on this tool should be confirmed using your organizations standard operating procedures.",
+  settings = NULL)
 }
 \arguments{
 \item{data}{A data frame containing the labs data. Data must be structured as one record per study participant per time point per lab measure.}
@@ -66,6 +67,8 @@ User can update this setting via the UI when \code{r_ratio_filter = TRUE}. Defau
 No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: This interactive graphic is 
 not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
 standard operating procedures."}.}
+
+\item{settings}{Optional list of settings arguments.  If provided, all other function parameters are ignored. Default: \code{NULL}.}
 }
 \description{
 This function creates an interactive graphic for the Evaluation of Drug-Induced Serious Hepatotoxicity (eDISH)

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -68,13 +68,15 @@ No warning is displayed if \code{warningText = ""}. Default: \code{"Caution: Thi
 not validated. Any clinical recommendations based on this tool should be confirmed using your organizations 
 standard operating procedures."}.}
 
-\item{settings}{Optional list of settings arguments.  If provided, all other function parameters are ignored. Default: \code{NULL}.}
+\item{settings}{Optional list of settings arguments to be converted to JSON using \code{jsonlite::toJSON(settings, auto_unbox = TRUE, dataframe = "rows", null = "null")}.  If provided, all other function parameters are ignored. Default: \code{NULL}.}
 }
 \description{
 This function creates an interactive graphic for the Evaluation of Drug-Induced Serious Hepatotoxicity (eDISH)
 }
 \examples{
 \dontrun{
+
+## Create eDISH figure customized to user data
 eDISH(data=adlbc, 
       id_col = "USUBJID",
       value_col = "AVAL", 
@@ -86,6 +88,20 @@ eDISH(data=adlbc,
                             AST = "Aspartate Aminotransferase (U/L)",
                             TB = "Bilirubin (umol/L)",
                             ALP = "Alkaline Phosphatase (U/L)"))
+
+## Create eDISH figure using a premade settings list
+settingsl <- list(id_col = "USUBJID",
+      value_col = "AVAL", 
+      measure_col = "PARAM", 
+      visitn_col = "VISITNUM", 
+      normal_col_low = "A1LO", 
+      normal_col_high = "A1HI", 
+      measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
+                             +                             AST = "Aspartate Aminotransferase (U/L)",
+                             +                             TB = "Bilirubin (umol/L)",
+                             +                             ALP = "Alkaline Phosphatase (U/L)"))
+eDISH(data=adlbc, settings = settingsl)
+
 }
 
 }

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -90,16 +90,25 @@ eDISH(data=adlbc,
                             ALP = "Alkaline Phosphatase (U/L)"))
 
 ## Create eDISH figure using a premade settings list
+group_cols_vec <- c("TRTP","SEX", "AGEGR1")
+
+filters_df <- data.frame(
+  value_col=c("TRTA", "SEX", "RACE", "AGEGR1"),
+  label = c("Treatment", "Sex", "RACE", "Age group")
+)
+
 settingsl <- list(id_col = "USUBJID",
       value_col = "AVAL", 
       measure_col = "PARAM", 
       visitn_col = "VISITNUM", 
       normal_col_low = "A1LO", 
       normal_col_high = "A1HI", 
+      group_cols = group_cols_vec,
+      filters = filters_df,
       measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
-                             +                             AST = "Aspartate Aminotransferase (U/L)",
-                             +                             TB = "Bilirubin (umol/L)",
-                             +                             ALP = "Alkaline Phosphatase (U/L)"))
+                            AST = "Aspartate Aminotransferase (U/L)",
+                            TB = "Bilirubin (umol/L)",
+                            ALP = "Alkaline Phosphatase (U/L)"))
 eDISH(data=adlbc, settings = settingsl)
 
 }

--- a/man/eDISH.Rd
+++ b/man/eDISH.Rd
@@ -73,3 +73,19 @@ standard operating procedures."}.}
 \description{
 This function creates an interactive graphic for the Evaluation of Drug-Induced Serious Hepatotoxicity (eDISH)
 }
+\examples{
+\dontrun{
+eDISH(data=adlbc, 
+      id_col = "USUBJID",
+      value_col = "AVAL", 
+      measure_col = "PARAM", 
+      visitn_col = "VISITNUM", 
+      normal_col_low = "A1LO", 
+      normal_col_high = "A1HI", 
+      measure_values = list(ALT = "Alanine Aminotransferase (U/L)",
+                            AST = "Aspartate Aminotransferase (U/L)",
+                            TB = "Bilirubin (umol/L)",
+                            ALP = "Alkaline Phosphatase (U/L)"))
+}
+
+}


### PR DESCRIPTION
Add ability to customize figure by specifying [settings arguments](https://github.com/ASA-DIA-InteractiveSafetyGraphics/safety-eDISH/wiki/Configuration), or by optionally passing entire settings list.  Also force widget to render in larger, popped out viewer window (as opposed to default smaller RStudio viewer pane).

Settings *not* included in this iteration:
- details
- point_size / point_size_options
- imputation_methods / imputation_values
- cuts
- display / display_options
- measureBounds
- populationProfileURL / participantProfileURL
- Webcharts settings